### PR TITLE
Min Signatures input field too small

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -402,7 +402,7 @@ p {
     display: flex;
 
     input {
-      width: 38px;
+      width: 52px;
       height: 38px;
     }
     .controller {


### PR DESCRIPTION
1.) Increase the width on the input field of min. Signature in Create a new wallet form. 