### PR TITLE
Typo in My Wallet>New Transactions>Advanced Options>Tag

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -402,7 +402,7 @@ p {
     display: flex;
 
     input {
-      width: 38px;
+      width: 52px;
       height: 38px;
     }
     .controller {

--- a/src/components/Wallet/NewTransaction.vue
+++ b/src/components/Wallet/NewTransaction.vue
@@ -63,8 +63,8 @@
         <input
           type="text"
           class="form-control"
-          placeholder="Teg transition"
-          aria-label="Teg transition"
+          placeholder="Tag transition"
+          aria-label="Tag transition"
           v-model="tag"
         >
       </div>


### PR DESCRIPTION
1.) Solved a typo error in Advanced option form while adding a new transaction. Changed from teg to tag.