### PR TITLE
feat: DEVOPS-1150 multisig migration to gcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# multisig
+# MOVED: multisig
+
+This repository has been moved to the [Zilliqa Developer](https://github.com/Zilliqa/zilliqa-developer) mono repo. This repository is only kept for historical reasons.
 
 For Ledger testing on localhost use Caddy for serving HTTPS (https://localhost).
 ```


### PR DESCRIPTION
This repository has been moved to the [Zilliqa Developer](https://github.com/Zilliqa/zilliqa-developer) mono repo. This repository is only kept for historical reasons.